### PR TITLE
Add basic MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ SHORTEN https://example.com CUSTOM key
 ```
 
 The server will respond with the short URL and PIN.
+
 ### Frontend Setup
 
 1. Navigate to the `ui` directory:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ This project is a URL shortener and analytics application built with React for t
    go run main.go
    ```
 
+### MCP Server
+
+A lightweight TCP-based server runs in parallel with the HTTP server. Set the `MCP_PORT` environment variable to configure the port (defaults to `5555`). Use a TCP client to connect and send commands like:
+
+```
+PING
+SHORTEN https://example.com
+SHORTEN https://example.com CUSTOM key
+```
+
+The server will respond with the short URL and PIN.
 ### Frontend Setup
 
 1. Navigate to the `ui` directory:

--- a/main.go
+++ b/main.go
@@ -23,6 +23,8 @@ func main() {
 	}
 
 	db := initDB()
+	// Start MCP server in a separate goroutine
+	startMCPServer(db)
 	http.HandleFunc("/{path...}", enableCors(func(w http.ResponseWriter, r *http.Request) {
 		handleURL(w, r, db)
 	}))

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bufio"
+	"database/sql"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"strings"
+)
+
+// startMCPServer starts a simple TCP server that accepts text based
+// commands to shorten URLs. It is intentionally minimal and supports
+// the following commands:
+//
+//	PING                        -> replies with PONG
+//	SHORTEN <url>               -> shorten the given URL
+//	SHORTEN <url> CUSTOM <key>  -> shorten with a custom key
+func startMCPServer(db *sql.DB) {
+	port := os.Getenv("MCP_PORT")
+	if port == "" {
+		port = "5555"
+	}
+
+	ln, err := net.Listen("tcp", ":"+port)
+	if err != nil {
+		log.Printf("failed to start MCP server: %v", err)
+		return
+	}
+	log.Printf("MCP server listening on %s", port)
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				log.Printf("MCP accept error: %v", err)
+				continue
+			}
+			go handleMCPConn(conn, db)
+		}
+	}()
+}
+
+func handleMCPConn(conn net.Conn, db *sql.DB) {
+	defer conn.Close()
+	scanner := bufio.NewScanner(conn)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		cmd := strings.ToUpper(fields[0])
+		switch cmd {
+		case "PING":
+			fmt.Fprintln(conn, "PONG")
+		case "SHORTEN":
+			handleMCPShorten(conn, db, fields[1:])
+		default:
+			fmt.Fprintln(conn, "ERR unknown command")
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		log.Printf("MCP read error: %v", err)
+	}
+}
+
+func handleMCPShorten(conn net.Conn, db *sql.DB, args []string) {
+	if len(args) < 1 {
+		fmt.Fprintln(conn, "ERR missing URL")
+		return
+	}
+	targetURL := args[0]
+	custom := false
+	customKey := ""
+	if len(args) >= 3 && strings.ToUpper(args[1]) == "CUSTOM" {
+		custom = true
+		customKey = args[2]
+	}
+	if _, err := checkURLValid(targetURL); err != nil {
+		fmt.Fprintln(conn, "ERR invalid URL")
+		return
+	}
+	newURL, err := createURL(targetURL, db, custom, customKey)
+	if err != nil {
+		fmt.Fprintf(conn, "ERR %v\n", err)
+		return
+	}
+	if err := saveURL(newURL, db); err != nil {
+		fmt.Fprintf(conn, "ERR %v\n", err)
+		return
+	}
+	fmt.Fprintf(conn, "%s %s %s\n", newURL.ShortURL, newURL.Url, newURL.Pin)
+}

--- a/utils.go
+++ b/utils.go
@@ -86,6 +86,16 @@ func createURL(url string, db *sql.DB, custom bool, customKey string) (shortURL,
 	}
 }
 
+// saveURL persists a generated shortURL into the database.
+func saveURL(url shortURL, db *sql.DB) error {
+	stmt, err := db.Prepare("INSERT INTO urls (name, redirect_url, date_created, pin) VALUES ($1, $2, $3, $4)")
+	if err != nil {
+		return err
+	}
+	_, err = stmt.Exec(url.ShortURL, url.Url, url.DateCreated, url.Pin)
+	return err
+}
+
 func generateCustomKey(db *sql.DB, customKey string) (string, error) {
 	stmt, err := db.Prepare("SELECT count(name) FROM urls where name = $1")
 	if err != nil {


### PR DESCRIPTION
## Summary
- implement a simple TCP-based MCP server for shortening URLs
- add helper to persist new URLs to DB
- launch MCP server from `main.go`
- document how to use the MCP server

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_684dfa18ac0083209eddb745cacc285d